### PR TITLE
updated to add attachments

### DIFF
--- a/slacker/slacker.js
+++ b/slacker/slacker.js
@@ -157,6 +157,8 @@ module.exports = function(RED) {
         return;
       }
       m.text = msg.payload;
+      //Added attachments
+      m.attachments = msg.attachments;
       if(m.hasOwnProperty('text')){
         node.controller.bot.say(m);
       }


### PR DESCRIPTION
Added m.attachments = msg.attachments before bot.say() to add attachments for slack messages. Use template node to set msg.attachments to as dictated here: https://api.slack.com/docs/message-attachments. template node must contain everything from [ to ] including [ and ].